### PR TITLE
Update checks

### DIFF
--- a/telebot.scm
+++ b/telebot.scm
@@ -3,6 +3,7 @@
                  getUpdates
                  sendMessage
                  forwardMessage
+		 resolve-query
                  sendPhoto
                  sendAudio
                  sendDocument

--- a/telebot.scm
+++ b/telebot.scm
@@ -24,6 +24,7 @@
                  answerInlineQuery
                  ;;; framework
                  is-message?
+		 is-edited_message?
                  is-inline_query?
                  is-chosen_inline_result?
                  poll-updates
@@ -248,6 +249,7 @@
       (not (equal? #f (alist-ref type update)))))
 
   (define is-message?              (update-predicate 'message))
+  (define is-edited_message?       (update-predicate 'edited_message))
   (define is-inline_query?         (update-predicate 'inline_query))
   (define is-chosen_inline_result? (update-predicate 'chosen_inline_result))
 

--- a/telebot.scm
+++ b/telebot.scm
@@ -28,6 +28,8 @@
 		 is-edited_message?
                  is-inline_query?
                  is-chosen_inline_result?
+		 is-text?
+		 is-location?
                  poll-updates
                  make-conversation-manager)
   (import chicken scheme)
@@ -247,12 +249,15 @@
 
   (define (update-predicate type)
     (lambda (update)
-      (not (equal? #f (alist-ref type update)))))
+      (not (equal? #f (resolve-query type update)))))
 
-  (define is-message?              (update-predicate 'message))
-  (define is-edited_message?       (update-predicate 'edited_message))
-  (define is-inline_query?         (update-predicate 'inline_query))
-  (define is-chosen_inline_result? (update-predicate 'chosen_inline_result))
+  (define is-message?              (update-predicate '(message)))
+  (define is-edited_message?       (update-predicate '(edited_message)))
+  (define is-inline_query?         (update-predicate '(inline_query)))
+  (define is-chosen_inline_result? (update-predicate '(chosen_inline_result)))
+
+  (define is-text?                 (update-predicate '(message text)))
+  (define is-location?             (update-predicate '(message location)))
 
   (define (poll-updates token handler)
     (let ((offset 0))


### PR DESCRIPTION
When messages are edited, but esp. when you use the new live location feature, the message key in the updates is no longer 'message' but 'edited_message' (for all but the first location messages of 'one go').

I added 'is-edited_message?', included 'resolve-query' in the list of exported functions (you defined it a second time in the echo.scm example, instead). Furthermore, in 'update-predicate' I use 'resolve-query' to be able to reach deeper into the update, resulting, finally, in 'is-text?' and 'is-location?'; alas, those two are 'dangerous', as they will break for edited messages, because I hardcodedly use 'message' still.