### PR TITLE
Abstract 'is-message?': returns #t for message and edited_message

### DIFF
--- a/telebot.scm
+++ b/telebot.scm
@@ -57,7 +57,7 @@
         cleaned-parameters)))
 
   (define (resolve-query query tree)
-    (fold (lambda (x y) (alist-ref x y))
+    (fold (lambda (x y) (alist-ref x y eqv? '()))
           tree
           query))
 
@@ -246,18 +246,20 @@
                              next_offset))
 
   ;;; framework
+  (define (is-update-type? type update)
+    (not (equal? '() (resolve-query type update))))
 
-  (define (update-predicate type)
+  (define (update-predicate types)
     (lambda (update)
-      (not (equal? #f (resolve-query type update)))))
+      (any (lambda (type) (is-update-type? type update)) types)))
 
-  (define is-message?              (update-predicate '(message)))
-  (define is-edited_message?       (update-predicate '(edited_message)))
-  (define is-inline_query?         (update-predicate '(inline_query)))
-  (define is-chosen_inline_result? (update-predicate '(chosen_inline_result)))
+  (define is-message?              (update-predicate '((message) (edited_message)) ))
+  (define is-edited_message?       (update-predicate '((edited_message)) ))
+  (define is-inline_query?         (update-predicate '((inline_query)) ))
+  (define is-chosen_inline_result? (update-predicate '((chosen_inline_result)) ))
 
-  (define is-text?                 (update-predicate '(message text)))
-  (define is-location?             (update-predicate '(message location)))
+  (define is-text?                 (update-predicate '((message text) (edited_message text)) ))
+  (define is-location?             (update-predicate '((message location) (edited_message location)) ))
 
   (define (poll-updates token handler)
     (let ((offset 0))


### PR DESCRIPTION
- in 'resolve-query': return '() instead of default #f from 'alist-ref': this way it doesn't fail when passed to 'fold' and didn't find anything, which expects a list and not a boolean; cleaner also: always returns what it found, even if it's nothing (empty list)
- then: check for '() instead of #f

- change 'update-predicate' to expect a list of lists: e.g. the update can have _either_ '(message text) _or_ '(edited_message text) to be a message of type text

- use 'is-edited_message?' if you still have to know if a message was edited